### PR TITLE
build: added libexpat build support

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -9,3 +9,6 @@
 [submodule "src/submodule_packages/pygments"]
 	path = src/submodule_packages/pygments
 	url = git@github.com:pygments/pygments.git
+[submodule "src/submodule_packages/libexpat"]
+	path = src/submodule_packages/libexpat
+	url = git@github.com:guyush1/libexpat.git

--- a/Dockerfile
+++ b/Dockerfile
@@ -19,6 +19,7 @@ RUN apt update && apt install -y \
     gcc-powerpc-linux-gnu \
     git \
     libncurses-dev \
+    libtool \
     m4  \
     make \
     patch \


### PR DESCRIPTION
This allows commands such as "info os files"
previously we had expat support on x86_64 only.