### PR TITLE
build: fix python frozen modules generation

### DIFF
--- a/src/compilation/frozen_python_modules.txt
+++ b/src/compilation/frozen_python_modules.txt
@@ -1,4 +1,3 @@
-abc
 _aix_support
 antigravity
 argparse
@@ -8,7 +7,6 @@ bdb
 bisect
 calendar
 cmd
-codecs
 codeop
 code
 <collections.**.*>
@@ -54,7 +52,6 @@ hmac
 imaplib
 <importlib.**.*>
 inspect
-io
 ipaddress
 <json.**.*>
 keyword


### PR DESCRIPTION
The problem was due to duplicate modules present both in the base frozen modules and also in the extra modules list file.

This commit should allow us to import gdb and pygments again.