### PR TITLE
build: enable gdb cross-architecture debugging

### DIFF
--- a/src/compilation/build.sh
+++ b/src/compilation/build.sh
@@ -527,7 +527,7 @@ function build_gdb() {
     >&2 fancy_title "Building gdb for $target_arch"
 
     ../configure --enable-static --with-static-standard-libraries --disable-inprocess-agent \
-                 --enable-targets=all \
+                 --enable-targets=all --enable-64-bit-bfd \
                  --enable-tui "$python_flag" \
                  --with-expat --with-libexpat-type="static" \
                  --with-gdb-datadir="/usr/share/gdb" --with-separate-debug-dir="/usr/lib/debug" \

--- a/src/compilation/build.sh
+++ b/src/compilation/build.sh
@@ -527,6 +527,7 @@ function build_gdb() {
     >&2 fancy_title "Building gdb for $target_arch"
 
     ../configure --enable-static --with-static-standard-libraries --disable-inprocess-agent \
+                 --enable-targets=all \
                  --enable-tui "$python_flag" \
                  --with-expat --with-libexpat-type="static" \
                  --with-gdb-datadir="/usr/share/gdb" --with-separate-debug-dir="/usr/lib/debug" \


### PR DESCRIPTION
This enables support for when gdb is debugging a cross-architecture binary, most commonly from gdbserver (which comes from another architecture).