### PR TITLE
Made `make clean` POSIX compliant

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -86,7 +86,7 @@ _pack-%: build-%-$(BUILD_TYPE)
 	fi
 
 clean-git-packages:
-	git submodule foreach '[[ "$$sm_path" == src/submodule_packages/* ]] && git clean -xffd && git restore .'
+	git submodule foreach 'echo "$$sm_path" | grep "^src/submodule_packages/.*" && git clean -xffd && git restore .'
 
 clean: clean-git-packages
 	rm -rf build


### PR DESCRIPTION
We used a bash-ism in make clean in the form of using `[[` in order to compare a string to a glob.

Apparently, not all computers use bash in git submodule for-each, so we use the grep command right now in order to make the command more shell-generic.