### PR TITLE
ci: Added a stage to build the compilation docker

### DIFF
--- a/.github/workflows/pr-pipeline.yaml
+++ b/.github/workflows/pr-pipeline.yaml
@@ -24,5 +24,8 @@ jobs:
     - name: Install dependencies
       run: sudo apt-get install -y wget
 
+    - name: Build compilation docker
+      run: make build-docker-image
+
     - name: Build
       run: make build-${{ matrix.architecture }}-${{ matrix.build_type }} -j$((`nproc`+1))


### PR DESCRIPTION
We do this so that we won't re-build the docker for each of the architectures.