### PR TITLE
build: Compile mips & mipel via a soft-float toolchain

### DIFF
--- a/src/compilation/build.sh
+++ b/src/compilation/build.sh
@@ -35,9 +35,9 @@ function set_compilation_variables() {
     elif [[ "$target_arch" == "powerpc" ]]; then
         export HOST=powerpc-linux-musl
     elif [[ "$target_arch" == "mips" ]]; then
-        export HOST=mips-linux-musl
+        export HOST=mips-linux-muslsf # We compile with a soft-float compiler to support a wide range of mips cpus.
     elif [[ "$target_arch" == "mipsel" ]]; then
-        export HOST=mipsel-linux-musl
+        export HOST=mipsel-linux-muslsf # We compile with a soft-float compiler to support a wide range of mips cpus.
     elif [[ "$target_arch" == "x86_64" ]]; then
         export HOST=x86_64-linux-musl
     fi

--- a/src/docker_utils/download_musl_toolchains.py
+++ b/src/docker_utils/download_musl_toolchains.py
@@ -20,8 +20,8 @@ ARCHS = {
     "arm" : "https://github.com/guyush1/musl-cross-make/releases/download/musl-gcc14/arm-linux-musleabi-cross.tgz",
     "aarch64" : "https://github.com/guyush1/musl-cross-make/releases/download/musl-gcc14/aarch64-linux-musl-cross.tgz",
     "powerpc" : "https://github.com/guyush1/musl-cross-make/releases/download/musl-gcc14/powerpc-linux-musl-cross.tgz",
-    "mips" : "https://github.com/guyush1/musl-cross-make/releases/download/musl-gcc14/mips-linux-musl-cross.tgz",
-    "mipsel" : "https://github.com/guyush1/musl-cross-make/releases/download/musl-gcc14/mipsel-linux-musl-cross.tgz",
+    "mips" : "https://github.com/guyush1/musl-cross-make/releases/download/musl-gcc14/mips-linux-muslsf-cross.tgz",
+    "mipsel" : "https://github.com/guyush1/musl-cross-make/releases/download/musl-gcc14/mipsel-linux-muslsf-cross.tgz",
 }
 CHUNK_SIZE = 65536
 MUSL_TOOLCHAINS_DIR = Path("/musl-toolchains")


### PR DESCRIPTION
Since a lot of mips devices do not have hardware level float support, we have moved to a soft-float mips toolchains.